### PR TITLE
Make precommit hook os-dependant

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For example,
 	LIBFLEXPATH=/home/me/code/libflex-git-clone
 	CONFIGPATH=/home/me/code/libflex-git-clone
 
-(2) Edit `precommitStatisticsHook.sh` to set
+(2) Edit `precommitStatisticsHook-<your os type>.sh` to set
 
 	dtraceDirectory=full-path-to-DTrace-repository-clone
 	libflexDirectory=full-path-to-libflex-repository-clone
@@ -128,7 +128,7 @@ The hooks can be enabled for mercurial by adding the following to
 `.hg/hgrc`:
 
 	[hooks]
-	pretxncommit    = ./precommitStatisticsHook.sh
+	pretxncommit    = ./precommitStatisticsHook-<your-os-type>.sh
 	commit          = ./postcommitStatisticsHook.sh
 
 The generated statistics are stored in the `Statistics/` subdirectory,

--- a/Statistics/726c6c23e19c6a7175a061940db8cba1a21973cb.txt
+++ b/Statistics/726c6c23e19c6a7175a061940db8cba1a21973cb.txt
@@ -1,0 +1,3 @@
+
+changeset: 278:726c6c23e19c6a7175a061940db8cba1a21973cb
+\n./noisy/noisy-linux-EN -O0 Examples/helloWorld.n -s

--- a/common/Makefile
+++ b/common/Makefile
@@ -2,6 +2,7 @@ TREEROOT        = ..
 
 include         $(TREEROOT)/config.local
 
+PRECOMMITHOOK = precommitStatisticsHook-$(OSTYPE).sh 
 COMMONPATH      = ../common
 COMPILERVARIANT = clang
 
@@ -83,7 +84,7 @@ all: installhooks lib$(LIBCOMMON)-$(OSTYPE)-$(COMMON_L10N).a $(CONFIGPATH)/confi
 #			Install the pre-commit hooks. There doesn't seem to be any other way to force people to install the hook when comitting on Noisy.
 #
 installhooks:
-	cp $(TREEROOT)/precommitStatisticsHook.sh $(TREEROOT)/.git/hooks/pre-commit
+	cp $(TREEROOT)/$(PRECOMMITHOOK) $(TREEROOT)/.git/hooks/pre-commit
 	cp $(TREEROOT)/postcommitStatisticsHook.sh $(TREEROOT)/.git/hooks/post-commit
 	chmod +x $(TREEROOT)/.git/hooks/pre-commit
 	chmod +x $(TREEROOT)/.git/hooks/post-commit

--- a/newton/Makefile
+++ b/newton/Makefile
@@ -2,6 +2,8 @@ TREEROOT	= ..
 
 include		$(TREEROOT)/config.local
 
+PRECOMMITHOOK = precommitStatisticsHook-$(OSTYPE).sh 
+
 COMMONPATH	= ../common
 NOISYPATH	= ../noisy
 INCLUDEPATH	= ../include
@@ -135,7 +137,7 @@ HEADERS		=\
 all: installhooks version.c lib$(LIBNEWTON)-$(OSTYPE)-$(NEWTON_L10N).a target $(CONFIGPATH)/config.$(OSTYPE)-$(MACHTYPE).$(COMPILERVARIANT) $(COMMONPATH)/config.$(OSTYPE)-$(MACHTYPE).$(COMPILERVARIANT) Makefile 
 
 installhooks:
-	cp $(TREEROOT)/precommitStatisticsHook.sh $(TREEROOT)/.git/hooks/pre-commit
+	cp $(TREEROOT)/$(PRECOMMITHOOK) $(TREEROOT)/.git/hooks/pre-commit
 	cp $(TREEROOT)/postcommitStatisticsHook.sh $(TREEROOT)/.git/hooks/post-commit
 	chmod +x $(TREEROOT)/.git/hooks/pre-commit
 	chmod +x $(TREEROOT)/.git/hooks/post-commit

--- a/noisy/Makefile
+++ b/noisy/Makefile
@@ -2,6 +2,7 @@ TREEROOT	= ..
 
 include		$(TREEROOT)/config.local
 
+PRECOMMITHOOK = precommitStatisticsHook-$(OSTYPE).sh 
 COMMONPATH	= ../common
 COMPILERVARIANT	= clang
 
@@ -125,7 +126,7 @@ all: installhooks lib$(LIBNOISY)-$(OSTYPE)-$(NOISY_L10N).a target $(CONFIGPATH)/
 #			Install the pre-commit hooks. There doesn't seem to be any other way to force people to install the hook when comitting on Noisy.
 #
 installhooks:
-	cp $(TREEROOT)/precommitStatisticsHook.sh $(TREEROOT)/.git/hooks/pre-commit
+	cp $(TREEROOT)/$(PRECOMMITHOOK) $(TREEROOT)/.git/hooks/pre-commit
 	cp $(TREEROOT)/postcommitStatisticsHook.sh $(TREEROOT)/.git/hooks/post-commit
 	chmod +x $(TREEROOT)/.git/hooks/pre-commit
 	chmod +x $(TREEROOT)/.git/hooks/post-commit

--- a/precommitStatisticsHook-darwin.sh
+++ b/precommitStatisticsHook-darwin.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-dtraceDirectory=/Users/jonathanlim/Documents/Compiler/DTrace-scripts
-libflexDirectory=/Users/jonathanlim/Documents/Compiler/libflex
+dtraceDirectory=
+libflexDirectory=
 trackingDirectory=Statistics
 statsFile=`git rev-parse HEAD`.txt
 

--- a/precommitStatisticsHook-linux.sh
+++ b/precommitStatisticsHook-linux.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+dtraceDirectory=
+libflexDirectory=
+trackingDirectory=Statistics
+statsFile=`git rev-parse HEAD`.txt
+
+#
+#	Since the pre-commit hook leads to a change of the hash, we save the hash at the point of commit in the file '.noisy-last-head'
+#
+echo `git rev-parse HEAD` > .noisy-last-head
+
+echo '' >> $trackingDirectory/$statsFile
+echo "changeset: `git rev-list --count HEAD`:`git rev-parse HEAD`" >> $trackingDirectory/$statsFile 
+
+cd $libflexDirectory && make clean all &
+
+#wait $!
+make clean
+make -j
+make README.sloccount
+
+cat version.c >> $trackingDirectory/$statsFile
+echo '\n./noisy/noisy-linux-EN -O0 Examples/helloWorld.n -s' >> $trackingDirectory/$statsFile
+./noisy/noisy-linux-EN -O0 Examples/helloWorld.n -s >> $trackingDirectory/$statsFile
+
+cp $trackingDirectory/$statsFile $trackingDirectory/latest.txt


### PR DESCRIPTION
This commit creates seperate precommit hooks for darwin and linux.
precommitStatisticsHook-darwin.sh is a copy of the original
precommitStatisticsHook.sh. In the linux version, linux-incompatible
commands are commented out. README is updated accordingly.

Makefiles under common, newton and noisy are modified to copy the
correct precommit hook based on os type defined in config.local.