### PR TITLE
Fix timestamp naming

### DIFF
--- a/newton/newton-irPass-smtBackend.c
+++ b/newton/newton-irPass-smtBackend.c
@@ -334,28 +334,34 @@ irPassSmtDivisorWalk(State *  N, Invariant *  parentInvariant, IrNode *  root, F
 void
 irPassSmtProcessConstraint(State *  N, Invariant *  parentInvariant, IrNode *  root, FILE *  outputFile)
 {
+    struct timeval tv;
+    gettimeofday(&tv,NULL);
+    printf("Start Tree Transform %s: %lu%06lu\n", parentInvariant->identifier, tv.tv_sec, tv.tv_usec);
+
     IrNode *  transformed = commonTreeTransform(N, root);
+
+    gettimeofday(&tv,NULL);
+    printf("End Tree Transform %s: %lu%06lu\n", parentInvariant->identifier, tv.tv_sec, tv.tv_usec);
 
     fprintf(outputFile, "(assert ");
 
-    struct timeval tv;
     gettimeofday(&tv,NULL);
-	printf("Start Tree Transform %s: %lu%06lu\n", parentInvariant->identifier, tv.tv_sec, tv.tv_usec);
+    printf("Start Tree Walk %s: %lu%06lu\n", parentInvariant->identifier, tv.tv_sec, tv.tv_usec);
 
     irPassSmtTreeWalk(N, parentInvariant, transformed, outputFile);
 
     gettimeofday(&tv,NULL);
-	printf("End Tree Transform %s: %lu%06lu\n", parentInvariant->identifier, tv.tv_sec, tv.tv_usec);
+    printf("End Tree Walk %s: %lu%06lu\n", parentInvariant->identifier, tv.tv_sec, tv.tv_usec);
 
     fprintf(outputFile, " )\n");
 
     gettimeofday(&tv,NULL);
-	printf("Start Divisor Walk %s: %lu%06lu\n", parentInvariant->identifier, tv.tv_sec, tv.tv_usec);
+    printf("Start Divisor Walk %s: %lu%06lu\n", parentInvariant->identifier, tv.tv_sec, tv.tv_usec);
 
     irPassSmtDivisorWalk(N, parentInvariant, transformed, outputFile);
 
     gettimeofday(&tv,NULL);
-	printf("End Divisor Walk %s: %lu%06lu\n", parentInvariant->identifier, tv.tv_sec, tv.tv_usec);
+    printf("End Divisor Walk %s: %lu%06lu\n", parentInvariant->identifier, tv.tv_sec, tv.tv_usec);
 
     return;
 }


### PR DESCRIPTION
This patch corrects the bug where previous versions print
"tree-walk" timestamps as "tree-transform" timestamps. After
this patch, the original "tree-walk" timestamps are printed
under the correct name and real "tree-transform" timestamps
are added.