### PR TITLE
Make the Noisy dot backend linux compatible

### DIFF
--- a/noisy/noisy-irPass-dotBackend.c
+++ b/noisy/noisy-irPass-dotBackend.c
@@ -39,6 +39,11 @@
 #include <stdlib.h>
 #include <setjmp.h>
 #include <sys/time.h>
+
+#ifdef NoisyOsLinux
+#include <time.h>
+#endif
+
 #include <string.h>
 #include <stdint.h>
 #include <inttypes.h>
@@ -397,7 +402,7 @@ noisyIrPassDotBackend(State *  N, Scope *  noisyIrTopScope, IrNode * noisyIrRoot
 
 	int			bufferLength, irAndSymbolTableSize = 0;
 	char *			buf = NULL;
-#ifdef NoisyOsMacOSX
+#if defined(NoisyOsMacOSX) || defined(NoisyOsLinux)
 	int			n = 0;
 	struct timeval		t;
 
@@ -425,7 +430,7 @@ noisyIrPassDotBackend(State *  N, Scope *  noisyIrTopScope, IrNode * noisyIrRoot
 		fatal(N, Emalloc);
 	}
 
-#ifdef NoisyOsMacOSX
+#if defined(NoisyOsMacOSX) || defined(NoisyOsLinux)
 	gettimeofday(&t, NULL);
 	ctime_r(&t.tv_sec, dateString);
 


### PR DESCRIPTION
At the moment, the noisy dot backend prints out nothing on linux builds, as the code for dot description generation is in a `#ifdef NoisyOsMacOSX` section.

The solution is tested to work on my machine.

I am wondering whether the `#if defined(NoisyOsMacOSX) || defined(NoisyOsLinux)` is actually necessary, as they are the only `NoisyOs`s