### PR TITLE
Use newtonParseQuantityExpression in newtonParseExponentialExpression

### DIFF
--- a/newton/newton-parser-expression.c
+++ b/newton/newton-parser-expression.c
@@ -437,23 +437,24 @@ newtonParseExponentialExpression(State * N, Scope * currentScope, IrNode * baseN
 
     /* exponents are automatically just one integer unless wrapped in parens */
     IrNode *    exponent = peekCheck(N, 1, kNewtonIrNodeType_TleftParen) ?
-        newtonParseNumericExpression(N, currentScope) :
+        newtonParseQuantityExpression(N, currentScope) :
         newtonParseInteger(N, currentScope);
 	addLeaf(N, expression, exponent);
 
 	expression->value = exponent->value;
+    /*
+    This check should be part of the dimension check pass instead.
 
-    /* If the base is a Physics quantity, the exponent must be an integer */
+    // If the base is a Physics quantity, the exponent must be an integer
 	if (!newtonIsDimensionless(baseNode->physics))
 	{
 	    baseNode->physics->value = pow(baseNode->physics->value, expression->value);
 		newtonPhysicsMultiplyExponents(N, baseNode->physics, expression->value);
 
-		/* Can't raise a dimension to a non integer value*/
+		// Can't raise a dimension to a non integer value
 		assert(exponent->value == (int) exponent->value);
 	}
-
-
+    */
     return expression;
 }
 


### PR DESCRIPTION
At the momemnt, newtonParseExponentialExpression uses
newtonParseNumericExpression, which generates a malformmed quantity
expression tree. This patch changes the use of
newtonParseExponentialExpression to newtonParseQuantityExpression, which
is known to generate a correct quantity epxression tree.

The dimension check that follows is commented out both to avoid
unexpected behaviour and because it should be part of the dimension
check pass instead.