### PR TITLE
Update help message for SMT2 backend

### DIFF
--- a/Statistics/aeeb11428bcca84e2ea1e25370ca60021a36e7a2.txt
+++ b/Statistics/aeeb11428bcca84e2ea1e25370ca60021a36e7a2.txt
@@ -1,0 +1,11 @@
+
+changeset: 335:aeeb11428bcca84e2ea1e25370ca60021a36e7a2
+\n./noisy/noisy-linux-EN -O0 Examples/helloWorld.n -s
+
+Informational Report:
+---------------------
+
+Non-zero routine residency time upper bounds and counts (0 calls, total of 0.0000 us):
+
+
+\n./newton/newton-linux-EN -S tmp.smt2 Examples/pendulum_acceleration.nt

--- a/newton/main.c
+++ b/newton/main.c
@@ -263,7 +263,11 @@ main(int argc, char *argv[])
 			jumpParameter = setjmp(N->jmpbuf);
 			if (!jumpParameter)
 			{
-				processNewtonFile(N, argv[optind++]);			}
+				/*
+				 * We use the last argument as the input file due to avoid confusion in case of
+				 * issue-223
+				 */
+				processNewtonFile(N, argv[argc-1]);			}
 			else
 			{
 				//TODO: we could intelligently use the incoming jumpParameter
@@ -305,7 +309,7 @@ usage(State *  N)
 						"                | (--version, --V)                                   \n"
 						"                | (--verbose <level>, -v <level>)                    \n"
 						"                | (--dot <level>, -d <level>)                        \n"
-						"                | (--smt <path to output file>, -S <path to output file>)\n"
+						"                | (--smt=<path to output file>, -S                   \n"
 						"                | (--bytecode <output file name>, -b <output file name>)\n"
 						"                | (--optimize <level>, -O <level>)                   \n"
 						"                | (--trace, -t)                                      \n"


### PR DESCRIPTION
This patch updates the help message to document the behaviour that
`--smt=<output-file>` must be used to specify the output file when
invoking the SMT2 backend.

It also makes newton to always take the last argument as the input
file, so that when someone accidentally uses:
`newton-linux-EN -S <output-file> <input-file>`
, the newton compiler does not use the <output-file> as its input.