### PR TITLE
Add support for factor trees in common-astTransform

### DIFF
--- a/Statistics/950507d693ff6dc4feffcb5d026cf0cdf8fbcea8.txt
+++ b/Statistics/950507d693ff6dc4feffcb5d026cf0cdf8fbcea8.txt
@@ -1,0 +1,11 @@
+
+changeset: 343:950507d693ff6dc4feffcb5d026cf0cdf8fbcea8
+\n./noisy/noisy-linux-EN -O0 Examples/helloWorld.n -s
+
+Informational Report:
+---------------------
+
+Non-zero routine residency time upper bounds and counts (0 calls, total of 0.0000 us):
+
+
+\n./newton/newton-linux-EN -S tmp.smt2 Examples/pendulum_acceleration.nt


### PR DESCRIPTION
This patch enables common-astTransform to handle quantity factor trees,
which is structually very similar to expression trees, except that the
X_SEQ node is replaced with a higPredBinOp node.

This commit also removes the code to handle malformed exponent trees, as
the tree representation is now (almost) fixed.

Tested after rebased onto issue-226, all functional tests passed.