### PR TITLE
Fix SMT2 backend for updated AST format

### DIFF
--- a/src/common/common-astTransform.c
+++ b/src/common/common-astTransform.c
@@ -116,8 +116,20 @@ IrNode *  expandMinus(State *  N, IrNode *  rootNode)
      * 
      * NB: the number is stored in the right child since it is more-or-less 0-1
      */
+
+    IrNode *  operand;
+
+    if (R(rootNode)->type == kNoisyIrNodeType_Xseq)
+    {
+        operand = L(R(rootNode));
+    }
+    else
+    {
+        operand = R(rootNode);
+    }
+
     IrNode *  expandedTree = genIrNode(N, kNewtonIrNodeType_Tminus, NULL, \
-                                       commonTreeTransform(N, L(R(rootNode))),\
+                                       commonTreeTransform(N, operand),\
                                        L(rootNode)->sourceInfo);
 
     irPassHelperColorIr(N, expandedTree, kNoisyIrNodeColorTreeTransformedColoring, true, false);

--- a/src/newton/newton-irPass-smtBackend.c
+++ b/src/newton/newton-irPass-smtBackend.c
@@ -392,7 +392,7 @@ irPassDeclareParameters(State *  N, Invariant *  input)
 void
 irPassSmtProcessInvariant(State *  N, Invariant *  input)
 {
-	IrNode *	current = input->constraints;
+	IrNode *	current = input->constraints->irParent;
 
 	irPassDeclareParameters(N, input);
 


### PR DESCRIPTION
Addresses #346.

Tested on all invariants, SMT2 backend itself does not produce any error, but a few(`DroppedBall.nt` and `VehicleDistance.nt`) failed in the parser and a few (`SimplePendulum`, `ActivityClassifier`, `JetEngine`, `Pendulum` and `StepCounter`) are reported `unsat`, 