### PR TITLE
Bug fix to print out the correct expression

### DIFF
--- a/src/newton/newton-irPass-dimensionalMatrixKernelPrinter.c
+++ b/src/newton/newton-irPass-dimensionalMatrixKernelPrinter.c
@@ -68,6 +68,11 @@ irPassDimensionalMatrixKernelPrinter(State *  N)
 
 	while (invariant)
 	{
+		/*
+		 *	We construct a temporary array to re-locate the positions of the permuted parameters
+		 */
+		int *		tmpPosition = (int *)calloc(invariant->dimensionalMatrixColumnCount, sizeof(int));
+
 		flexprint(N->Fe, N->Fm, N->Fpinfo, "The corresponding kernels:\n\n");
 
 		if (invariant->numberOfUniqueKernels == 0)
@@ -118,6 +123,11 @@ irPassDimensionalMatrixKernelPrinter(State *  N)
 				/*
 				 *	Prints out the a table of the symbolic expressions implied by the Pi groups derived from the kernels.	
 				 */
+				for (int j = 0; j < invariant->dimensionalMatrixColumnCount; j++)
+				{
+					tmpPosition[invariant->permutedIndexArrayPointer[countKernel * invariant->dimensionalMatrixColumnCount + j]] = j;
+				}
+
 				flexprint(N->Fe, N->Fm, N->Fpinfo, "\tThere are in total %d Pi-groups\n", invariant->kernelColumnCount);
 				for (int col = 0; col < invariant->kernelColumnCount; col++)
 				{
@@ -126,7 +136,7 @@ irPassDimensionalMatrixKernelPrinter(State *  N)
 					for (int row = 0; row < invariant->dimensionalMatrixColumnCount; row++)
 					{
 						flexprint(N->Fe, N->Fm, N->Fpinfo, "#%c%c", 'A'+(row/10), '0'+ (row%10) );
-						flexprint(N->Fe, N->Fm, N->Fpinfo, "^(%2g)  ", invariant->nullSpace[countKernel][invariant->permutedIndexArrayPointer[countKernel * invariant->dimensionalMatrixColumnCount + row]][col]);
+						flexprint(N->Fe, N->Fm, N->Fpinfo, "^(%2g)  ", invariant->nullSpace[countKernel][tmpPosition[row]][col]);
 					}
 					flexprint(N->Fe, N->Fm, N->Fpinfo, "\n");
 				}
@@ -135,6 +145,8 @@ irPassDimensionalMatrixKernelPrinter(State *  N)
 			}
 		}
 		flexprint(N->Fe, N->Fm, N->Fpinfo, "\n");
+
+		free(tmpPosition);
 
 		invariant = invariant->next;
 	}


### PR DESCRIPTION
Added a temporary array to relocate the positions for the exponents within expressions. The expressions should now be correct.

	Kernel 1 is a valid kernel
	  -0  -1  -1  -0
	  -1  -0  -0  -1
	   1   0   0   0
	   0   1   0   0
	   0   0   1   0
	   0   0   0   1

	The ordering of parameters are as follows
	 #A3  #A5  #A2  #A0  #A4  #A1 

	There are in total 4 Pi-groups
	Pi-group 0 is
	#A0^( 0)  #A1^( 0)  #A2^( 1)  #A3^(-0)  #A4^( 0)  #A5^(-1)  
	Pi-group 1 is
	#A0^( 1)  #A1^( 0)  #A2^( 0)  #A3^(-1)  #A4^( 0)  #A5^(-0)  
	Pi-group 2 is
	#A0^( 0)  #A1^( 0)  #A2^( 0)  #A3^(-1)  #A4^( 1)  #A5^(-0)  
	Pi-group 3 is
	#A0^( 0)  #A1^( 1)  #A2^( 0)  #A3^(-0)  #A4^( 0)  #A5^(-1)  

Addresses #363.