### PR TITLE
Fix input->constraints pointing to NULL

### DIFF
--- a/src/newton/newton-irPass-smtBackend.c
+++ b/src/newton/newton-irPass-smtBackend.c
@@ -392,6 +392,11 @@ irPassDeclareParameters(State *  N, Invariant *  input)
 void
 irPassSmtProcessInvariant(State *  N, Invariant *  input)
 {
+	if (input->constraints == NULL)
+	{
+		return;
+	}
+
 	IrNode *	current = input->constraints->irParent;
 
 	irPassDeclareParameters(N, input);


### PR DESCRIPTION
Under certain circumstances, when there is no constraint in the invariantList, `input->constriants` would point to `NULL`, hence causing the invalid access for `current = input->constraints->irParent`.

We add an `if` statement to check if this is, in fact, pointing to `NULL`, if it is, then we return directly without executing the following lines in `irPassSmtProcessInvariant(State *  N, Invariant *  input)`.

Fixes issue #375 