### PR TITLE
Replace HTTPS URLs with SSH in .submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "submodules/eigen"]
 	path = submodules/eigen
-	url = https://github.com/eigenteam/eigen-git-mirror.git
+	url = git@github.com:eigenteam/eigen-git-mirror.git
 [submodule "submodules/wirth-tools"]
 	path = submodules/wirth-tools
-	url = https://github.com/phillipstanleymarbell/Wirth-tools.git
+	url = git@github.com:phillipstanleymarbell/Wirth-tools.git
 [submodule "submodules/libflex"]
 	path = submodules/libflex
-	url = https://github.com/phillipstanleymarbell/libflex.git
+	url = git@github.com:phillipstanleymarbell/libflex.git
 [submodule "submodules/dtrace-scripts"]
 	path = submodules/dtrace-scripts
-	url = https://github.com/phillipstanleymarbell/DTrace-scripts.git
+	url = git@github.com:phillipstanleymarbell/DTrace-scripts.git


### PR DESCRIPTION
> Since we're already mostly using SSH connections it would be more convenient to change the HTTPS URLs in the .submodule file to SSH ones instead. This way, when cloning with --recursive the process would not stop to ask for username/password.

Resolves #450.