### PR TITLE
Replace submodule urls with relative ones

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "submodules/eigen"]
 	path = submodules/eigen
-	url = https://github.com/eigenteam/eigen-git-mirror.git
+	url = ../../eigenteam/eigen-git-mirror.git
 [submodule "submodules/wirth-tools"]
 	path = submodules/wirth-tools
-	url = https://github.com/phillipstanleymarbell/Wirth-tools.git
+	url = ../../phillipstanleymarbell/Wirth-tools.git
 [submodule "submodules/libflex"]
 	path = submodules/libflex
-	url = https://github.com/phillipstanleymarbell/libflex.git
+	url = ../../phillipstanleymarbell/libflex.git
 [submodule "submodules/dtrace-scripts"]
 	path = submodules/dtrace-scripts
-	url = https://github.com/phillipstanleymarbell/DTrace-scripts.git
+	url = ../../phillipstanleymarbell/DTrace-scripts.git


### PR DESCRIPTION
With this, the method used to clone the main repository is used automatically for the submodules, too. Solves #450. Based on [this article](https://www.gniibe.org/memo/software/git/using-submodule.html).