### PR TITLE
Add findExpressionIdentifiers to common-irHelpers

### DIFF
--- a/src/common/common-irHelpers.c
+++ b/src/common/common-irHelpers.c
@@ -383,3 +383,47 @@ printDimensionsOfNode(State *  N, IrNode *  n, FlexPrintBuf *  flexBuf)
 
 	return;
 }
+
+/*
+ *	Find unique Symbols in expression.
+ *	Return: A chain of IrNodes, shallow copies of the ones detected.
+ */
+IrNode *
+findExpressionIdentifiers(State *  N, IrNode *  root)
+{
+	int	i = 0;
+	IrNode *	currSymbolNode = findNthIrNodeOfType(N, root, kNewtonIrNodeType_Tidentifier, i++);
+	if (currSymbolNode == NULL)
+	{
+		return NULL;
+	}
+
+	IrNode *	head = shallowCopyIrNode(N, currSymbolNode);
+	IrNode *	tail = head;
+
+	while ((currSymbolNode = findNthIrNodeOfType(N, root, kNewtonIrNodeType_Tidentifier, i++)) != NULL)
+	{
+		bool	alreadyAdded = false;
+
+		for (IrNode *  currNode = head; currNode != NULL; currNode = currNode->irRightChild)
+		{
+			if (currNode->symbol == currSymbolNode->symbol)
+			{
+				alreadyAdded = true;
+				break;
+			}
+		}
+		if (alreadyAdded == true)
+		{
+			continue;
+		}
+
+		IrNode *	newNode = shallowCopyIrNode(N, currSymbolNode);
+		
+		tail->irRightChild = newNode;
+		tail->irRightChild->irParent = tail;
+		tail = tail->irRightChild;
+	}
+
+	return head;
+}

--- a/src/common/common-irHelpers.h
+++ b/src/common/common-irHelpers.h
@@ -53,6 +53,7 @@ IrNode *	findNthIrNodeOfTypeHelper(State *  N, IrNode *  root, IrNodeType expect
 IrNode *	findNthIrNodeOfTypesHelper(State *  N, IrNode *  root, IrNodeType productionOrToken, int firsts[kNoisyIrNodeTypeMax][kNoisyIrNodeTypeMax], int *  nth);
 IrNodeType	getTypeFromOperatorSubtree(State *  N, IrNode *  n);
 void		printDimensionsOfNode(State *  N, IrNode *  n, FlexPrintBuf *  flexBuf);
+IrNode *	findExpressionIdentifiers(State *  N, IrNode *  root);
 
 #define L(node)		(node)->irLeftChild
 #define R(node)		(node)->irRightChild


### PR DESCRIPTION
>A new function in `common-utils.c` that returns a list of *new* `IrNodes` that are shallow copies of the unique identifier `IrNodes` in the expression. The IrNodes are linked together using `irRightChild` and `irParent`.

Function signature:
```
IrNode * findExpressionIdentifiers(State *  N, IrNode *  root);
```
-----
Function is essentially moved to common-irHelpers to be of use in other parts of the codebase.

The function provides an interface to find the unique identifiers used in a `quantityExpression`. As it is now, it returns a list of IrNodes with the shallow copies of the original IrNodes. Can be of use when creating argument lists for a specific expression. View issue #479 for more details.
Addresses #479.