### PR TITLE
Implementation of the signal-typedef-to command line option. Fixes al…

### DIFF
--- a/src/common/common-data-structures.h
+++ b/src/common/common-data-structures.h
@@ -1185,6 +1185,12 @@ typedef struct
 	int 			targetParamLocatedKernel;
 
 	/*
+	 *	This is data type that a signal will be typedef'ed to
+	 *	in the signal typedef generation backend
+	 */
+	char *		signalTypedefDatatype;
+
+	/*
 	 *	We keep a global handle on the list of module scopes, for easy reference.
 	 *	In this use case, the node->identifier holds the scopes string name, and we
 	 *	chain then using their prev/next fields.

--- a/src/common/common-utils.c
+++ b/src/common/common-utils.c
@@ -331,6 +331,21 @@ init(CommonMode mode)
 	 */
 	N->targetParamLocatedKernel = 0;
 
+	/*
+	 *	This is data type that a signal will be typedef'ed to
+	 *	in the signal typedef generation backend. The default
+	 *	data type is "double"
+	 */
+	N->signalTypedefDatatype = calloc(kCommonMaxBufferLength, sizeof(char));
+	if (N->signalTypedefDatatype == NULL)
+	{
+		fatal(NULL, Emalloc);
+	}
+	else
+	{
+		strcpy(N->signalTypedefDatatype, "double");
+	}
+
 	return N;
 }
 

--- a/src/newton/main.c
+++ b/src/newton/main.c
@@ -117,6 +117,7 @@ main(int argc, char *argv[])
 			{"physicalGroup1", required_argument, 0, 491},
 			{"physicalGroup2", required_argument, 0, 492},
 			{"generate-header", required_argument, 0, 493},
+			{"signal-typedef-to", required_argument, 0, 496},
 			{0,			0,			0,	0}
 		};
 
@@ -449,6 +450,12 @@ main(int argc, char *argv[])
 				break;
 			}
 
+			case 496:
+			{
+				strcpy(N->signalTypedefDatatype, optarg);
+				break;
+			}
+
 			case '?':
 			{
 				/*
@@ -538,6 +545,8 @@ usage(State *  N)
 						"                | (--pigrouptoast, -a)                                       \n"
 						"                | (--codegen <path to output file>, -g <path to output file>)\n"
 						"                | (--RTLcodegen <path to output file>, -l <path to output file>)\n"
+						"                | (--generate-header=<path to output file>					  \n"
+						"                | (--signal-typedef-to=<data type string>					  \n"
 						"                | (--trace, -t)                                              \n"
 						"                | (--statistics, -s)                                         \n"
 						"                | (--latex, -x)                                              \n"

--- a/src/newton/newton-irPass-signalTypedefGenerationBackend.c
+++ b/src/newton/newton-irPass-signalTypedefGenerationBackend.c
@@ -66,8 +66,6 @@
 #include "newton-symbolTable.h"
 #include "newton-irPass-invariantSignalAnnotation.h"
 
-char const signalDefaultDatatype[] = "double";
-
 void
 irPassSignalTypedefGenerationProcessNewtonSources(State *  N)
 {
@@ -84,7 +82,7 @@ irPassSignalTypedefGenerationProcessNewtonSources(State *  N)
 
 	while(oneIrNode != NULL)
     {
-        flexprint(N->Fe, N->Fm, N->Fph, "typedef %s %s;\n", signalDefaultDatatype, oneIrNode->irLeftChild->tokenString);
+        flexprint(N->Fe, N->Fm, N->Fph, "typedef %s %s;\n", N->signalTypedefDatatype, oneIrNode->irLeftChild->tokenString);
 
         oneIrNode = findNthIrNodeOfType(N, N->newtonIrRoot, kNewtonIrNodeType_PbaseSignalDefinition, count++);
     }
@@ -111,9 +109,11 @@ irPassSignalTypedefGenerationBackend(State *  N)
 			
 			consolePrintBuffers(N);
 		}
+		else
+		{
+			fprintf(signalTypedefHeaderFile, "%s", N->Fph->circbuf);
 
-		fprintf(signalTypedefHeaderFile, "%s", N->Fph->circbuf);
-
-		fclose(signalTypedefHeaderFile);
+			fclose(signalTypedefHeaderFile);
+		}
 	}
 }


### PR DESCRIPTION
…so a segmentation fault in the signal typedef header generation when it failed to open the destination file.

Addresses #552.