### PR TITLE
Add build GitHub Action

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: install LLVM
+      run: sudo apt-get --assume-yes install llvm
     - uses: actions/checkout@v2
       with:
         submodules: recursive


### PR DESCRIPTION
Adds a GitHub Action that will checkout and build the repository using `make`. This action will run on Pull Requests targeting the master branch. This way we can be sure that a PR at least builds before it gets merged.

The next steps would be to add more actions to perform testing.

Closes #541.