### PR TITLE
Renamed current LLVM IR pass files

### DIFF
--- a/analysis/statistics/19262427723191bed7d73928011574047f721dde.txt
+++ b/analysis/statistics/19262427723191bed7d73928011574047f721dde.txt
@@ -1,0 +1,48 @@
+
+changeset: 1179:19262427723191bed7d73928011574047f721dde
+char kNewtonVersion[] = "0.3-alpha-1179 (19262427723191bed7d73928011574047f721dde) (build 01-21-2022-17:21-blackgeorge@blackgeorge-IdeaPad-L340-17IRH-Gaming-Linux-5.3.0-62-generic-x86_64)";
+
+./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+
+./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+

--- a/src/common/common-data-structures.h
+++ b/src/common/common-data-structures.h
@@ -713,7 +713,7 @@ typedef enum
 	kNewtonIrPassInvariantSignalAnnotation			= (1 << 10),
 
 	kNewtonIrPassPiGroupsSignalAnnotation			= (1 << 11),
-	kNewtonIrPassLLVMIR								= (1 << 12),
+	kNewtonIrPassLLVMIRDimensionCheck								= (1 << 12),
 	kNewtonIrPassSensorsDisable				= (1 << 13),
 	/*
 	 *	Code depends on this bringing up the rear.

--- a/src/newton/Makefile
+++ b/src/newton/Makefile
@@ -91,7 +91,7 @@ SOURCES		=\
 		newton-timeStamps.c\
 		main.c\
 		newton-eigenLibraryInterface.cpp\
-		newton-irPass-LLVMIR.cpp\
+		newton-irPass-LLVMIR-dimension-check.cpp\
 
 
 #
@@ -119,7 +119,7 @@ OBJS		=\
 		newton-irPass-dotBackend.$(OBJECTEXTENSION)\
 		newton-irPass-smtBackend.$(OBJECTEXTENSION)\
 		newton-irPass-estimatorSynthesisBackend.$(OBJECTEXTENSION)\
-		newton-irPass-LLVMIR.$(OBJECTEXTENSION)\
+		newton-irPass-LLVMIR-dimension-check.$(OBJECTEXTENSION)\
 		newton-irPass-invariantSignalAnnotation.$(OBJECTEXTENSION)\
 		newton-irPass-piGroupsSignalAnnotation.$(OBJECTEXTENSION)\
 		newton-irPass-ipsaBackend.$(OBJECTEXTENSION)\
@@ -159,7 +159,7 @@ CGIOBJS		=\
 		newton-irPass-dotBackend.$(OBJECTEXTENSION)\
 		newton-irPass-smtBackend.$(OBJECTEXTENSION)\
 		newton-irPass-estimatorSynthesisBackend.$(OBJECTEXTENSION)\
-		newton-irPass-LLVMIR.$(OBJECTEXTENSION)\
+		newton-irPass-LLVMIR-dimension-check.$(OBJECTEXTENSION)\
 		newton-irPass-invariantSignalAnnotation.$(OBJECTEXTENSION)\
 		newton-irPass-piGroupsSignalAnnotation.$(OBJECTEXTENSION)\
 		newton-irPass-estimatorSynthesisBackend/$(OBJECTEXTENSION)\
@@ -198,7 +198,7 @@ LIBNEWTONOBJS =\
 		newton-irPass-dotBackend.$(OBJECTEXTENSION)\
 		newton-irPass-smtBackend.$(OBJECTEXTENSION)\
 		newton-irPass-estimatorSynthesisBackend.$(OBJECTEXTENSION)\
-		newton-irPass-LLVMIR.$(OBJECTEXTENSION)\
+		newton-irPass-LLVMIR-dimension-check.$(OBJECTEXTENSION)\
 		newton-irPass-invariantSignalAnnotation.$(OBJECTEXTENSION)\
 		newton-irPass-piGroupsSignalAnnotation.$(OBJECTEXTENSION)\
 		newton-irPass-ipsaBackend.$(OBJECTEXTENSION)\
@@ -234,7 +234,7 @@ HEADERS		=\
 		newton-irPass-dotBackend.h\
 		newton-irPass-smtBackend.h\
 		newton-irPass-estimatorSynthesisBackend.h\
-		newton-irPass-LLVMIR.h\
+		newton-irPass-LLVMIR-dimension-check.h\
 		newton-irPass-invariantSignalAnnotation.h\
 		newton-irPass-piGroupsSignalAnnotation.h\
 		newton-irPass-ipsaBackend.h\
@@ -299,7 +299,7 @@ newton-eigenLibraryInterface.$(OBJECTEXTENSION): newton-eigenLibraryInterface.cp
 	$(CXX) $(FLEXFLAGS) $(INCDIRS) $(CXXFLAGS) $(WFLAGS) $(OPTFLAGS) $(LINTFLAGS) $<
 	$(CXX) $(FLEXFLAGS) $(INCDIRS) $(CXXFLAGS) $(WFLAGS) $(OPTFLAGS) $<
 
-newton-irPass-LLVMIR.$(OBJECTEXTENSION): newton-irPass-LLVMIR.cpp
+newton-irPass-LLVMIR-dimension-check.$(OBJECTEXTENSION): newton-irPass-LLVMIR-dimension-check.cpp
 	$(CXX) $(FLEXFLAGS) $(INCDIRS) $(CXXFLAGS) $(WFLAGS) $(OPTFLAGS) $(LINTFLAGS) $<
 	$(CXX) $(FLEXFLAGS) $(INCDIRS) $(CXXFLAGS) $(WFLAGS) $(OPTFLAGS) $<
 

--- a/src/newton/main.c
+++ b/src/newton/main.c
@@ -410,7 +410,7 @@ main(int argc, char *argv[])
 
 			case 'L':
 			{
-				N->irPasses |= kNewtonIrPassLLVMIR;
+				N->irPasses |= kNewtonIrPassLLVMIRDimensionCheck;
 				N->llvmIR = optarg;
 				break;
 			}

--- a/src/newton/newton-irPass-LLVMIR-dimension-check.cpp
+++ b/src/newton/newton-irPass-LLVMIR-dimension-check.cpp
@@ -523,7 +523,7 @@ dimensionalityCheck(Function &  llvmIrFunction, State *  N)
 
 
 void
-irPassLLVMIR(State *  N)
+irPassLLVMIRDimensionCheck(State *  N)
 {
 	if (N->llvmIR == nullptr)
 	{

--- a/src/newton/newton-irPass-LLVMIR-dimension-check.h
+++ b/src/newton/newton-irPass-LLVMIR-dimension-check.h
@@ -4,7 +4,7 @@ extern "C"
 {
 #	endif /* __cplusplus */
 
-void    irPassLLVMIR(State *  N);
+void    irPassLLVMIRDimensionCheck(State *  N);
 
 #	ifdef __cplusplus
 } /* extern "C" */

--- a/src/newton/newton.c
+++ b/src/newton/newton.c
@@ -76,7 +76,7 @@
 #include "newton-irPass-invariantSignalAnnotation.h"
 #include "newton-irPass-piGroupsSignalAnnotation.h"
 #include "newton-irPass-ipsaBackend.h"
-#include "newton-irPass-LLVMIR.h"
+#include "newton-irPass-LLVMIR-dimension-check.h"
 #include "newton-irPass-dimensionalMatrixAnnotation.h"
 #include "newton-irPass-dimensionalMatrixPiGroups.h"
 #include "newton-irPass-dimensionalMatrixPrinter.h"
@@ -192,9 +192,9 @@ processNewtonFile(State *  N, char *  filename)
 	{
 		irPassPiGroupsSignalAnnotation(N);
 	}
-	if (N->irPasses & kNewtonIrPassLLVMIR)
+	if (N->irPasses & kNewtonIrPassLLVMIRDimensionCheck)
 	{
-		irPassLLVMIR(N);
+		irPassLLVMIRDimensionCheck(N);
 	}
 	/*
 	 *	Dot backend.


### PR DESCRIPTION
This PR renames the LLVM IR-related files and function, to switch from the generic LLVM IR names to a more specific format in order to reflect the fact that they are performing a dimensionality check.

This will help when the next LLVM IR pass is added, to disambiguate names.