### PR TITLE
Add parameter physics to Modality->_physics

### DIFF
--- a/src/newton/newton-irPass-sensors.c
+++ b/src/newton/newton-irPass-sensors.c
@@ -162,6 +162,11 @@ irPassSensorsLoadSensor(State *  N, IrNode *  sensorNode)
 
 		// modality->signal;
 
+		/*
+		 *	Modality _physics (temporary until there is signal functionality)
+		 */
+		modality->_physics = parameter->irRightChild->physics;
+
 		IrNode *	tempNode = NULL;
 		int		n = 0;
 


### PR DESCRIPTION
Temporary measure until the Signals infrastructure is up.

Note that the Physics has a bug where the subindex field is not
correctly populated (always 0).

Closes #582.