### PR TITLE
Issue 601 - The function names don't match in matrixadv.h and matrixadv.c

### DIFF
--- a/applications/newton/llvm-ir/state-estimator/Makefile
+++ b/applications/newton/llvm-ir/state-estimator/Makefile
@@ -10,14 +10,23 @@ CC:=clang # Currently tested with clang-12/clang-13
 BIN?=RandomAccelerationWalk-estSynth
 COMMON_FLAGS=-Wall -Wextra
 
-default: app.ll
+default: app.o
 
 app.ll: $(BIN).ll matrix.ll matrixadv.ll
-	llvm-link -S -o $@ $<
+	@echo llvm-linking $*.ll
+	llvm-link -S -o $@ $^
 
 %.ll : %.c
 	@echo Compiling $*.c
 	$(_QUIET)$(CC) -g -S -emit-llvm $(COMMON_FLAGS) -o $@ $<
 
+app.s : app.ll
+	@echo llc $*.ll
+	llc -o $@ $<
+
+app.o : app.s
+	@echo Compiling $*.s
+	$(_QUIET)$(CC) -g -o $@ $<
+
 clean::
-	$(_QUIET)rm -f *.ll
+	$(_QUIET)rm -f *.ll *.s *.o

--- a/applications/newton/llvm-ir/state-estimator/RandomAccelerationWalk-estSynth.c
+++ b/applications/newton/llvm-ir/state-estimator/RandomAccelerationWalk-estSynth.c
@@ -173,7 +173,7 @@ void filterUpdate(CoreState *cState, double Z[MEASURE_DIMENSION], time dt)
 		r++;
 	}
 
-	matrix *HPHm_T_inv = matrixInverse(HPHm_T);
+	matrix *HPHm_T_inv = inverseMatrix(HPHm_T);
 	matrix *Kg = multiplyMatrix(PHm_T, HPHm_T_inv);
 
 	// S <- S + Kg (Z - HS)

--- a/applications/newton/llvm-ir/state-estimator/matrixadv.h
+++ b/applications/newton/llvm-ir/state-estimator/matrixadv.h
@@ -4,7 +4,7 @@
 
 void LUdecomposition(matrix* a, matrix** l, matrix** u);
 double determinantMatrix(matrix* a);
-matrix* matrixInverse(matrix* a);
+matrix* inverseMatrix(matrix* a);
 matrix* solver(matrix* a, matrix* b);
 
 #endif


### PR DESCRIPTION
Hi, 

In this PR, I'd like to fix the function name mismatch problem in `matrixadv.h` and `matrixadv.c`.

And it might be helpful to get an executable file automatically by `Makefile`, as it could be used in our prospective benchmark work.

Hope this makes sense!