### PR TITLE
Specify LLVM version to install in GitHub CI.

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: install LLVM
-      run: sudo apt-get --assume-yes install llvm
+      run: sudo apt-get --assume-yes install llvm-12
     - uses: actions/checkout@v2
       with:
         submodules: recursive
@@ -30,4 +30,4 @@ jobs:
         echo "OSTYPE=linux" >> config.local
         echo "MACHTYPE=x86_64" >> config.local
     - name: make
-      run: make
+      run: make LLVM_CONFIG=llvm-config-12

--- a/analysis/statistics/77d3c17c9b70e98d6b575a46553c3515834dc43a.txt
+++ b/analysis/statistics/77d3c17c9b70e98d6b575a46553c3515834dc43a.txt
@@ -1,0 +1,48 @@
+
+changeset: 1315:77d3c17c9b70e98d6b575a46553c3515834dc43a
+char kNewtonVersion[] = "0.3-alpha-1315 (77d3c17c9b70e98d6b575a46553c3515834dc43a) (build 09-21-2022-12:16-blackgeorge@blackgeorge-IdeaPad-L340-17IRH-Gaming-Linux-5.3.0-62-generic-x86_64)";
+
+./src/noisy/noisy-linux-EN -O0 applications/noisy/helloWorld.n -s
+
+./src/newton/newton-linux-EN -v 0 -eP applications/newton/invariants/ViolinWithTemperatureDependence-pigroups.nt
+
+Informational Report:
+---------------------
+Invariant "ViolinWithTemperatureDependenceForPiGroups" has 2 unique kernels, each with 2 column(s)...
+
+	Kernel 0 is a valid kernel:
+
+		   1   1
+		-0.5  -0
+		   1   0
+		 0.5   0
+		   0  -1
+		  -0  -1
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 0, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^( 0)  P5^(-0)  
+
+			Pi group 0, Pi 1 is:	P0^(-0)  P1^( 1)  P2^( 0)  P3^( 0)  P4^(-1)  P5^(-1)  
+
+
+	Kernel 1 is a valid kernel:
+
+		   1   0
+		-0.5   1
+		   1  -2
+		 0.5  -1
+		  -0  -2
+		   0  -2
+
+
+		The ordering of parameters is:	P1 P0 P3 P2 P4 P5 
+
+			Pi group 1, Pi 0 is:	P0^(-0.5)  P1^( 1)  P2^(0.5)  P3^( 1)  P4^(-0)  P5^( 0)  
+
+			Pi group 1, Pi 1 is:	P0^( 1)  P1^( 0)  P2^(-1)  P3^(-2)  P4^(-2)  P5^(-2)  
+
+
+
+


### PR DESCRIPTION
When running `make` in the CI, we override the `LLVM_CONFIG` variable so that the CI can find the right version of `llvm-config` to use.

Addresses #625.